### PR TITLE
wsParseInputFrame data length size fix

### DIFF
--- a/lib/websocket.c
+++ b/lib/websocket.c
@@ -285,7 +285,7 @@ enum wsFrameType wsParseInputFrame(uint8_t *inputFrame, size_t inputLength,
             *dataPtr = &inputFrame[2 + payloadFieldExtraBytes + 4];
             *dataLength = payloadLength;
 		
-            uint8_t i;
+            size_t i;
             for (i = 0; i < *dataLength; i++) {
                 (*dataPtr)[i] = (*dataPtr)[i] ^ maskingKey[i%4];
             }


### PR DESCRIPTION
When payload length is greater than 255, the control variable i overflowed thus causing a dead loop. This fix uses the same type for i as for ending condition variable *dataLength. 

By the way, your work on cwebsocket project is amazing. Thanks a great deal! 

-Minghua
